### PR TITLE
Validate Build Status [EDO-1095]

### DIFF
--- a/Actions/CreateTfsBuildAction.cs
+++ b/Actions/CreateTfsBuildAction.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Inedo.BuildMaster;
 using Inedo.BuildMaster.Extensibility.Actions;
 using Inedo.BuildMaster.Extensibility.Agents;
@@ -7,6 +8,9 @@ using Microsoft.TeamFoundation.Build.Client;
 
 namespace Inedo.BuildMasterExtensions.TFS
 {
+    /// <summary>
+    /// Gets or sets the build number if not empty, or includes all builds in the search.
+    /// </summary>
     [ActionProperties(
         "Create TFS Build",
         "Creates a new build in TFS.",
@@ -19,10 +23,21 @@ namespace Inedo.BuildMasterExtensions.TFS
     public sealed class CreateTfsBuildAction : TfsActionBase
     {
         /// <summary>
+        /// Gets or sets the build number if not empty, or includes all builds in the search.
+        /// </summary>
+        public string BuildNumber { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the action should wait until the build completes before continuing.
         /// </summary>
         [Persistent]
         public bool WaitForCompletion { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the action should validate a successful build status.
+        /// </summary>
+        [Persistent]
+        public bool ValidateBuild{ get; set; }
 
         /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.
@@ -68,6 +83,46 @@ namespace Inedo.BuildMasterExtensions.TFS
                     this.LogDebug("TFS Build status reported: " + ((IQueuedBuild)s).Status);
                 };
                 queuedBuild.WaitForBuildCompletion(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(this.Timeout));
+            }
+            if(ValidateBuild)
+                ValidateBuildStatus();
+        }
+
+        private void ValidateBuildStatus()
+        {
+            LogDebug("Validating build completion.");
+            var collection = this.GetTeamProjectCollection();
+
+            var buildService = collection.GetService<IBuildServer>();
+            var buildDefinition = buildService.GetBuildDefinition(this.TeamProject, this.BuildDefinition);
+
+            
+            var spec = buildService.CreateBuildDetailSpec(this.TeamProject, this.BuildDefinition);
+            spec.MaxBuildsPerDefinition = 1;
+            spec.QueryOrder = BuildQueryOrder.FinishTimeDescending;
+
+
+            var result = buildService.QueryBuilds(spec);
+            var build = result.Builds.FirstOrDefault();
+            if (build == null)
+                throw new InvalidOperationException(string.Format("Build {0} for team project {1} definition {2} did not return any builds.", this.BuildNumber, this.TeamProject, this.BuildDefinition));
+
+            if (build.Status != BuildStatus.Succeeded)
+            {
+                this.LogError(string.Format(
+                        "There was a build error during the TFS Build {0} for team project {1} and the Validate Build Status option was "+
+                        "selected for this build.",
+                        this.BuildNumber, this.TeamProject)
+                    );
+
+                var buildErrors = InformationNodeConverters.GetBuildErrors(build);
+
+                // Should this be LogError or LogDebug?
+                this.LogError("Errors reported: ");
+                foreach (IBuildError buildError in buildErrors)
+                    this.LogError(string.Format("{0}; Line {1}: ErrMsg {2}", buildError.ServerPath, buildError.LineNumber, buildError.Message));
+
+                return;
             }
         }
     }

--- a/Actions/CreateTfsBuildActionEditor.cs
+++ b/Actions/CreateTfsBuildActionEditor.cs
@@ -11,6 +11,7 @@ namespace Inedo.BuildMasterExtensions.TFS
         private ValidatingTextBox txtTeamProject;
         private ValidatingTextBox txtBuildDefinition;
         private CheckBox chkWaitForCompletion;
+        private CheckBox chkValidateBuild;
 
         public override void BindToForm(ActionBase extension)
         {
@@ -19,6 +20,7 @@ namespace Inedo.BuildMasterExtensions.TFS
             this.txtTeamProject.Text = action.TeamProject;
             this.txtBuildDefinition.Text = action.BuildDefinition;
             this.chkWaitForCompletion.Checked = action.WaitForCompletion;
+            this.chkValidateBuild.Checked = action.ValidateBuild;
         }
 
         public override ActionBase CreateFromForm()
@@ -27,7 +29,8 @@ namespace Inedo.BuildMasterExtensions.TFS
             {
                 TeamProject = this.txtTeamProject.Text,
                 BuildDefinition = this.txtBuildDefinition.Text,
-                WaitForCompletion = this.chkWaitForCompletion.Checked
+                WaitForCompletion = this.chkWaitForCompletion.Checked,
+                ValidateBuild = this.chkValidateBuild.Checked
             };
         }
 
@@ -48,6 +51,7 @@ namespace Inedo.BuildMasterExtensions.TFS
             };
 
             this.chkWaitForCompletion = new CheckBox() { Text = "Wait For Completion" };
+            this.chkValidateBuild = new CheckBox() { Text = "Validate Build Success" };
 
             this.Controls.Add(
                 new FormFieldGroup(
@@ -67,6 +71,12 @@ namespace Inedo.BuildMasterExtensions.TFS
                     "If checked, the BuildMaster execution will wait until the build is completed before continuing to the next action.",
                     true,
                     new StandardFormField("", this.chkWaitForCompletion)
+                ),
+                new FormFieldGroup(
+                    "Validate Build Status",
+                    "If checked, the BuildMaster execution will validate the TFS Build Status and fail if the build has failed.",
+                    true,
+                    new StandardFormField("", this.chkValidateBuild)
                 )
             );
         }


### PR DESCRIPTION
**Issue**
Create TFS Build deployment action used the status of build queue as a determiner of build failure. This is good in events where the queue fails, but in cases where the build fails this would (confusingly) return a response that the "Create TFS Build" action completed successfully. 

**Description of Changes**
1. Action/CreateTFSBuildActionEditor.cs was modified to include a data element for "Validate Build Status". 
2. Action/CreateTFSBuildAction.cs was modified with a check for the ValidateBuild boolean and if found would then call a function which makes a fresh query and checks the build.Status and if it is != IBuildStatus Succeeded it fails out and returns the list of BuildErrors to the interface.

**Concerns**
Redundancy might be a concern; could not find an appropriate method to ensure direct correlation to utilized context build. At this point this.BuildNumber does not match spec.BuildNumber from TFS so fails on a query.