### PR TITLE
TFS 2015 on-prem authentication and GetBuilds changes..

### DIFF
--- a/VisualStudioOnline/ImportVsoArtifactAction.cs
+++ b/VisualStudioOnline/ImportVsoArtifactAction.cs
@@ -59,7 +59,8 @@ namespace Inedo.BuildMasterExtensions.TFS.VisualStudioOnline
                 configurer, 
                 this, 
                 this.TeamProject, 
-                this.BuildNumber, 
+                this.BuildNumber,
+                this.BuildDefinition,
                 new ArtifactIdentifier(this.Context.ApplicationId, this.Context.ReleaseNumber, this.Context.BuildNumber, this.Context.DeployableId, this.ArtifactName)
             );
         }

--- a/VisualStudioOnline/QueueVsoBuildAction.cs
+++ b/VisualStudioOnline/QueueVsoBuildAction.cs
@@ -66,7 +66,7 @@ namespace Inedo.BuildMasterExtensions.TFS.VisualStudioOnline
 
             var api = new TfsRestApi(configurer.BaseUrl, this.TeamProject)
             {
-                UserName = configurer.UserName,
+                UserName = string.IsNullOrEmpty(configurer.Domain) ? configurer.UserName : string.Format("{0}\\{1}", configurer.Domain, configurer.UserName),
                 Password = configurer.Password
             };
 

--- a/VisualStudioOnline/TfsRestApi.cs
+++ b/VisualStudioOnline/TfsRestApi.cs
@@ -113,6 +113,7 @@ namespace Inedo.BuildMasterExtensions.TFS.VisualStudioOnline
             
             if (!string.IsNullOrEmpty(this.UserName))
             {
+                request.Credentials = new NetworkCredential(this.UserName, this.Password);
                 request.Headers[HttpRequestHeader.Authorization] = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(this.UserName + ":" + this.Password));
             }
 
@@ -166,6 +167,7 @@ namespace Inedo.BuildMasterExtensions.TFS.VisualStudioOnline
 
             if (!string.IsNullOrEmpty(this.UserName))
             {
+                request.Credentials = new NetworkCredential(this.UserName, this.Password);
                 request.Headers[HttpRequestHeader.Authorization] = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(this.UserName + ":" + this.Password));
             }
 

--- a/VisualStudioOnline/TfsRestApi.cs
+++ b/VisualStudioOnline/TfsRestApi.cs
@@ -15,6 +15,7 @@ namespace Inedo.BuildMasterExtensions.TFS.VisualStudioOnline
 
         public string ApiVersion { get; set; } = "2.0";
         public string BuildNumber { get; set; }
+        public int Definition { get; set; }
         public int? Top { get; set; }
         public string ResultFilter { get; set; }
         public string StatusFilter { get; set; }
@@ -27,6 +28,8 @@ namespace Inedo.BuildMasterExtensions.TFS.VisualStudioOnline
                 buffer.AppendFormat("api-version={0}&", this.ApiVersion);
             if (this.BuildNumber != null)
                 buffer.AppendFormat("buildNumber={0}&", this.BuildNumber);
+            if (this.Definition != 0)
+                buffer.AppendFormat("definitions={0}&", this.Definition);
             if (this.Top != null)
                 buffer.AppendFormat("$top={0}&", this.Top);
             if (this.ResultFilter != null)
@@ -67,6 +70,13 @@ namespace Inedo.BuildMasterExtensions.TFS.VisualStudioOnline
         public GetBuildResponse[] GetBuilds(string buildNumber = null, string resultFilter = null, string statusFilter = null, int? top = null)
         {
             var query = new QueryString() { BuildNumber = buildNumber, ResultFilter = resultFilter, StatusFilter = statusFilter, Top = top };
+
+            return this.Invoke<GetBuildsResponse>("GET", "build/builds", query).value;
+        }
+
+        public GetBuildResponse[] GetBuilds(int buildDefinition, string buildNumber = null, string resultFilter = null, string statusFilter = null, int? top = null)
+        {
+            var query = new QueryString() { Definition=buildDefinition, BuildNumber = buildNumber, ResultFilter = resultFilter, StatusFilter = statusFilter, Top = top };
 
             return this.Invoke<GetBuildsResponse>("GET", "build/builds", query).value;
         }

--- a/VisualStudioOnline/VsoArtifactImporter.cs
+++ b/VisualStudioOnline/VsoArtifactImporter.cs
@@ -54,8 +54,7 @@ namespace Inedo.BuildMasterExtensions.TFS.VisualStudioOnline
 
             if (builds.Length == 0)
                 throw new InvalidOperationException($"Could not find build number {buildNumber}. Ensure there is a successful, completed build with this number.");
-            if (!string.IsNullOrEmpty(buildNumber) && builds.Length > 1)
-                throw new InvalidOperationException($"A build number was specified and there were multiple builds found with build number {buildNumber}.");
+            
 
             var build = builds.FirstOrDefault(b => b.definition.id == buildDefinition.id);
 

--- a/VisualStudioOnline/VsoArtifactImporter.cs
+++ b/VisualStudioOnline/VsoArtifactImporter.cs
@@ -29,7 +29,7 @@ namespace Inedo.BuildMasterExtensions.TFS.VisualStudioOnline
 
             var api = new TfsRestApi(configurer.BaseUrl, teamProject)
             {
-                UserName = configurer.UserName,
+                UserName = string.IsNullOrEmpty(configurer.Domain) ? configurer.UserName : string.Format("{0}\\{1}", configurer.Domain, configurer.UserName),
                 Password = configurer.Password
             };
 

--- a/VisualStudioOnline/VsoArtifactImporter.cs
+++ b/VisualStudioOnline/VsoArtifactImporter.cs
@@ -35,28 +35,28 @@ namespace Inedo.BuildMasterExtensions.TFS.VisualStudioOnline
 
             logger.LogInformation($"Finding last successful build...");
             var buildDefinitions = api.GetBuildDefinitions();
-            
+
             var buildDefinition = buildDefinitions.FirstOrDefault(b => b.name == buildDefinitionName);
-            
+
             if (buildDefinition == null)
-               {
+            {
                 throw new InvalidOperationException($"The build definition {buildDefinitionName} could not be found.");
-               }
-            
+            }
+
             logger.LogInformation($"Finding {Util.CoalesceStr(buildNumber, "last successful")} build...");
 
             var builds = api.GetBuilds(
+                buildDefinition: buildDefinition.id,
                 buildNumber: InedoLib.Util.NullIf(buildNumber, ""),
                 resultFilter: "succeeded",
-                statusFilter: "completed"
-                //,top: 2
+                statusFilter: "completed",
+                top: 2
             );
 
             if (builds.Length == 0)
                 throw new InvalidOperationException($"Could not find build number {buildNumber}. Ensure there is a successful, completed build with this number.");
             
-
-            var build = builds.FirstOrDefault(b => b.definition.id == buildDefinition.id);
+            var build = builds.FirstOrDefault();
 
             string tempFile = Path.GetTempFileName();
             try

--- a/VisualStudioOnline/VsoBuildImporter.cs
+++ b/VisualStudioOnline/VsoBuildImporter.cs
@@ -39,6 +39,7 @@ namespace Inedo.BuildMasterExtensions.TFS.VisualStudioOnline
                 this,
                 this.TeamProject,
                 this.TfsBuildNumber,
+                this.BuildDefinition,
                 new ArtifactIdentifier(context.ApplicationId, context.ReleaseNumber, context.BuildNumber, context.DeployableId, this.ArtifactName)
             );
 


### PR DESCRIPTION
Hi, 
I've made some changes based on my requirement for TFS 2015 on-prem which are slightly different from your existing VSO integration.

**Authentication Changes** 
aka - supports domain credentials and handle TFS on prem's negotiated auth requirements:

[20911b4](https://github.com/elvza/bmx-tfs/commit/20911b455de4a6eb6186c234d5d261b04f551170) 
[1bc60bc](https://github.com/elvza/bmx-tfs/commit/1bc60bcdfcba3312ec37ec99ab71b362ef33d988)

**Build Retrieval**
aka - some changes around how I think builds should be retrieved when there are 'multiple build definitions' in a single team project which have the 'same build numbering scheme'.

[3952231](https://github.com/elvza/bmx-tfs/commit/39522310b02562f151659116c96bc2de0a3f00d7)
[4541472](https://github.com/elvza/bmx-tfs/commit/4541472b2ab3bff4857eab0943f8eab9594612b5)
[37c6260](https://github.com/elvza/bmx-tfs/commit/37c6260ace91e16ecb01f28d849c326ada8aa0ed)

Have a look to see if they still suite your VSO test suite. I've done some rudimentary debug type tests against VSO to confirm whether the changes I've made negatively impact VSO integration but I'd like to get your input too.